### PR TITLE
chore: add setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Open SWE is an open-source cloud-based asynchronous coding agent built with [Lan
 - 🧑‍💻 **End to end task management**: Open SWE will automatically create GitHub issues for tasks, and create pull requests which will close the issue when implementation is complete.
 
 
+## Setup
+
+Run the setup script to install dependencies:
+
+```bash
+yarn setup
+```
+
+On Windows PowerShell:
+
+```powershell
+yarn setup:ps
+```
+
 ## Usage
 
 Open SWE can be used in multiple ways:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "format:check": "turbo format:check",
     "lint": "turbo lint",
     "lint:fix": "turbo lint:fix",
-    "test": "turbo test"
+    "test": "turbo test",
+    "setup": "bash scripts/setup.sh",
+    "setup:ps": "powershell -ExecutionPolicy Bypass -File scripts/setup.ps1"
   },
   "devDependencies": {
     "turbo": "^2.5.0",

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = "Stop"
+
+$requiredNodeMajor = 20
+$requiredYarnVersion = "3.5.1"
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+  Write-Error "Node.js v$requiredNodeMajor is required"
+}
+
+$nodeMajor = (node -v).TrimStart('v').Split('.')[0]
+if ($nodeMajor -ne $requiredNodeMajor.ToString()) {
+  Write-Error "Node.js v$requiredNodeMajor is required. You have $(node -v)."
+}
+
+if (-not (Get-Command corepack -ErrorAction SilentlyContinue)) {
+  Write-Error "corepack is required"
+}
+
+corepack enable | Out-Null
+$yarnVersion = yarn -v
+if ($yarnVersion.Trim() -ne $requiredYarnVersion) {
+  Write-Error "Yarn $requiredYarnVersion is required. You have $yarnVersion."
+}
+
+yarn install
+Write-Host "Setup complete"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_node_major=20
+required_yarn_version="3.5.1"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js v$required_node_major is required" >&2
+  exit 1
+fi
+
+node_major=$(node -v | sed -E 's/^v([0-9]+).*/\1/')
+if [[ "$node_major" != "$required_node_major" ]]; then
+  echo "Node.js v$required_node_major is required. You have $(node -v)." >&2
+  exit 1
+fi
+
+if ! command -v corepack >/dev/null 2>&1; then
+  echo "corepack is required" >&2
+  exit 1
+fi
+
+corepack enable >/dev/null 2>&1
+yarn_version=$(yarn -v)
+if [[ "$yarn_version" != "$required_yarn_version" ]]; then
+  echo "Yarn $required_yarn_version is required. You have $yarn_version." >&2
+  exit 1
+fi
+
+yarn install
+
+echo "Setup complete"


### PR DESCRIPTION
## Summary
- add bash and PowerShell setup scripts to verify tool versions and install dependencies
- expose setup scripts via package.json and document usage in README

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`
- `yarn setup`


------
https://chatgpt.com/codex/tasks/task_b_68a0338d7abc8320b5e0ffacbaf920d2